### PR TITLE
[FEATURE] Handle inputs with multiple words

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This extension adds autocomplete functionality to TYPO3 indexed search fields.
 * Supports TYPO3 12 and 13
 * No further dependencies
 * Comes with limited styling for easy customizability
+* Handles inputs with multiple words
 
 
 ## Installation

--- a/Resources/Public/JavaScript/autocomplete_for_indexedsearch.js
+++ b/Resources/Public/JavaScript/autocomplete_for_indexedsearch.js
@@ -58,6 +58,7 @@
 		const endpoint = suggestionsContainer.dataset.endpoint;
 		const minlength = typeof suggestionsContainer.dataset.minlength !== 'undefined' ? suggestionsContainer.dataset.minlength : 2;
 		const sword = event.target.value.trim();
+		const caretpos = event.target.selectionStart;
 
 		// check if the entered sword is long enough
 		if (sword.length < minlength) {
@@ -77,7 +78,7 @@
 		clearTimeout(debounceTimeout);
 		debounceTimeout = setTimeout(function() {
 			clearTimeout(debounceTimeout);
-			autocomplete(sword, endpoint, suggestionsContainer);
+			autocomplete(sword, endpoint, suggestionsContainer, caretpos);
 		}, 250);
 	}
 
@@ -133,9 +134,10 @@
 	/**
 	 * Performs autocomplete
 	 */
-	async function autocomplete(sword, endpoint, suggestionsContainer) {
+	async function autocomplete(sword, endpoint, suggestionsContainer, caretpos) {
 		let formData = new FormData();
 		formData.append('tx_autocompleteforindexedsearch_autocomplete[sword]', sword);
+		formData.append('tx_autocompleteforindexedsearch_autocomplete[caretpos]', caretpos);
 
 		const response = await fetch(endpoint, {
 			method: 'POST',


### PR DESCRIPTION
Up to now, typing multiple words like "typo3 auto" did not yield any suggestions.

This patch adds support for handling such cases:
Input is split by space, and the *current* word
(indicated by the caret position) is completed.

Examples:
- "typ|" gives suggestions for "typ" as before
- "typo3 aut|" gives suggestions for "aut"
- "typ| auto" gives suggestions for "typ"

The other words are properly appended and prepended in the suggestions, giving "cool typo3 autocomplete" when typing "cool typ| autocomplete".

Resolves: https://github.com/RKlingler/autocomplete_for_indexedsearch/issues/1