### PR TITLE
[FEATURE] Support autocomplete in TYPO3v11

### DIFF
--- a/Classes/Service/SuggestionsService.php
+++ b/Classes/Service/SuggestionsService.php
@@ -63,7 +63,20 @@ final class SuggestionsService
 			// Collecting all pages IDs in which to search
 			// filtering out ALL pages that are not accessible due to restriction containers. Does NOT look for "no_search" field!
 			$pageRepository = GeneralUtility::makeInstance(PageRepository::class);
-			$idList = $pageRepository->getPageIdsRecursive($searchRootPageIdList, 9999);
+
+
+			if ((new \TYPO3\CMS\Core\Information\Typo3Version)->getMajorVersion() >= 12) {
+				$idList = $pageRepository->getPageIdsRecursive($searchRootPageIdList, 9999);
+			} else {
+				$cObj = $this->configurationManager->getContentObject();
+				$idListStr = '';
+				foreach ($searchRootPageIdList as $rootPageId) {
+					$idListStr .= ',' . $cObj->getTreeList('-' . $rootPageId, 9999);
+				}
+				$idList = explode(',', trim($idListStr, ','));
+				$idList = array_map('intval', $idList);
+			}
+
 			$queryBuilder->andWhere(
 				$queryBuilder->expr()->in(
 					'IP.data_page_id',

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
 		"issues": "https://github.com/RKlingler/autocomplete_for_indexedsearch/issues"
 	},
 	"require": {
-		"typo3/cms-core": "^12.4 || ^13.4",
-		"typo3/cms-extbase": "^12.4 || ^13.4",
-		"typo3/cms-fluid": "^12.4 || ^13.4",
-		"typo3/cms-frontend": "^12.4 || ^13.4",
-		"typo3/cms-indexed-search": "^12.4 || ^13.4"
+		"typo3/cms-core": "^11.5 || ^12.4 || ^13.4",
+		"typo3/cms-extbase": "^11.5 || ^12.4 || ^13.4",
+		"typo3/cms-fluid": "^11.5 || ^12.4 || ^13.4",
+		"typo3/cms-frontend": "^11.5 || ^12.4 || ^13.4",
+		"typo3/cms-indexed-search": "^11.5 || ^12.4 || ^13.4"
 	},
 	"require-dev": {
 		"friendsofphp/php-cs-fixer": "^3.65",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -16,7 +16,7 @@ $EM_CONF[$_EXTKEY] = [
 	'version' => '1.0.1',
 	'constraints' => [
 		'depends' => [
-			'typo3' => '12.4.0-13.4.99',
+			'typo3' => '11.5.0-13.4.99',
 		],
 	],
 ];


### PR DESCRIPTION
Use a different way to get a list of pages in TYPO3 v11 and earlier, because PageRepository::getPageIdsRecursive() is not available there.

Tested with TYPO3 v11.5.41